### PR TITLE
DP-53: Création de l'entité Blog avec slug automatique, relation avec…

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "jsonwebtoken": "^9.0.2",
         "pg": "^8.16.3",
         "reflect-metadata": "^0.2.2",
+        "slugify": "^1.6.6",
         "type-graphql": "^2.0.0-rc.2",
         "typeorm": "^0.3.25"
       },
@@ -2123,6 +2124,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/split2": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",
+    "slugify": "^1.6.6",
     "type-graphql": "^2.0.0-rc.2",
     "typeorm": "^0.3.25"
   },

--- a/backend/src/common/entities/BaseTimeEntity.ts
+++ b/backend/src/common/entities/BaseTimeEntity.ts
@@ -1,0 +1,18 @@
+import { BaseEntity, CreateDateColumn, UpdateDateColumn, PrimaryGeneratedColumn } from "typeorm";
+import { Field, ID, ObjectType } from "type-graphql";
+  
+@ObjectType()
+    export abstract class BaseTimeEntity extends BaseEntity {
+    @PrimaryGeneratedColumn()
+    @Field(() => ID)
+    id: number;
+
+    @CreateDateColumn({ type: "timestamp", default: () => "CURRENT_TIMESTAMP" })
+    @Field()
+    createdAt: Date;
+
+    @UpdateDateColumn({ type: "timestamp", default: () => "CURRENT_TIMESTAMP" })
+    @Field()
+    updatedAt: Date;
+}
+  

--- a/backend/src/config/data-source.ts
+++ b/backend/src/config/data-source.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import { DataSource } from "typeorm";
 import * as dotenv from 'dotenv';
 import { User } from "../entities/User";
+import { Blog } from "../entities/Blog";
 
 dotenv.config();
 
@@ -13,7 +14,7 @@ const dataSource = new DataSource({
     password: process.env.DB_PASSWORD,
     database: process.env.DB_DATABASE,
 
-    entities: [User],
+    entities: [User, Blog],
     synchronize: true, //synchronise automatiquement la base de données(sans avoir besoin de faire des migrations : NE JAMAIS UTILISER EN PROD)
     // logging: ['error', 'query']  // verifie les erreurs et les requêtes pour débugguer
     logging: true  // verifie les erreurs et les requêtes pour débugguer

--- a/backend/src/entities/Blog.ts
+++ b/backend/src/entities/Blog.ts
@@ -1,0 +1,33 @@
+import { Entity, Column , BeforeInsert, BeforeUpdate, ManyToOne } from "typeorm";
+import { Field, ID, ObjectType } from "type-graphql";
+import { BaseTimeEntity } from "../common/entities/BaseTimeEntity";
+import slugify from 'slugify';
+import { User } from "./User";
+
+
+@Entity()
+@ObjectType()
+export class Blog extends BaseTimeEntity {
+
+    @ManyToOne(() => User, user => user.blogs, { nullable: false })
+    @Field(() => User)
+    author: User; //FIXME: rendre automatiquement le user connecté comme auteur du blog
+
+    @Column({ length: 100, nullable: false })
+    @Field(() => String)
+    name: string
+
+    @Column({ nullable: false, unique: true })
+    @Field(()=> String)
+    slug: string
+
+    @Column({ length: 1000, nullable: false })
+    @Field(() => String)
+    description: string
+
+    @BeforeInsert()
+    @BeforeUpdate()
+    generateSlug() {
+      this.slug = slugify(this.name, { lower: true });
+    }
+}

--- a/backend/src/entities/User.ts
+++ b/backend/src/entities/User.ts
@@ -1,4 +1,4 @@
-import { Entity, BaseEntity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany } from "typeorm"
+import { Entity, Column, OneToMany } from "typeorm"
 import { Field, ID, ObjectType } from "type-graphql"
 import { BaseTimeEntity } from "../common/entities/BaseTimeEntity"
 import { Blog } from "./Blog"

--- a/backend/src/entities/User.ts
+++ b/backend/src/entities/User.ts
@@ -1,12 +1,11 @@
-import { Entity, BaseEntity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from "typeorm"
+import { Entity, BaseEntity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany } from "typeorm"
 import { Field, ID, ObjectType } from "type-graphql"
+import { BaseTimeEntity } from "../common/entities/BaseTimeEntity"
+import { Blog } from "./Blog"
 
 @Entity()
 @ObjectType()
-export class User extends BaseEntity {
-    @PrimaryGeneratedColumn()
-    @Field(() => ID)
-    id: number
+export class User extends BaseTimeEntity {
 
     @Column({ length: 100, nullable: false })
     @Field(() => String)
@@ -28,11 +27,8 @@ export class User extends BaseEntity {
     @Field()
     isActive: boolean
 
-    @CreateDateColumn({ type: "timestamp", default: () => "CURRENT_TIMESTAMP" })
-    @Field()
-    createdAt: Date;
+    @OneToMany(() => Blog, blog => blog.author)
+    @Field(() => [Blog])
+    blogs: Blog[];
 
-    @UpdateDateColumn({ type: "timestamp", default: () => "CURRENT_TIMESTAMP" })
-    @Field()
-    updatedAt: Date;
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,6 +17,7 @@ const start = async () => {
 
     const schema = await buildSchema({
       resolvers: [HelloResolver, UserResolver, BlogResolver],
+      validate: true, // active les decorators de class-validator
     });
 
     const server = new ApolloServer({ schema });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,9 +3,10 @@ import { startStandaloneServer } from '@apollo/server/standalone';
 import "reflect-metadata";
 import dataSource from "./config/data-source";
 import { buildSchema } from 'type-graphql';
+import * as dotenv from 'dotenv';
 import { HelloResolver } from './resolvers/HelloResolver';
 import { UserResolver } from './resolvers/UserResolver';
-import * as dotenv from 'dotenv';
+import { BlogResolver } from './resolvers/BlogResolver';
 
 dotenv.config();
 
@@ -15,7 +16,7 @@ const start = async () => {
     console.log("✅ Database connected");
 
     const schema = await buildSchema({
-      resolvers: [HelloResolver, UserResolver],
+      resolvers: [HelloResolver, UserResolver, BlogResolver],
     });
 
     const server = new ApolloServer({ schema });

--- a/backend/src/inputs/blog/BlogInput.ts
+++ b/backend/src/inputs/blog/BlogInput.ts
@@ -1,0 +1,14 @@
+import { Field, InputType } from "type-graphql";
+import { Length } from "class-validator";
+
+@InputType()
+export class BlogInput {
+  @Field()
+  @Length(5, 255)
+  name: string;
+
+  @Field()
+  @Length(10, 1000)
+  description: string;
+}
+

--- a/backend/src/inputs/blog/BlogInput.ts
+++ b/backend/src/inputs/blog/BlogInput.ts
@@ -1,14 +1,16 @@
 import { Field, InputType } from "type-graphql";
-import { Length } from "class-validator";
+import { IsNotEmpty, Length } from "class-validator";
 
 @InputType()
 export class BlogInput {
   @Field()
   @Length(5, 255)
+  @IsNotEmpty()
   name: string;
 
   @Field()
   @Length(10, 1000)
+  @IsNotEmpty()
   description: string;
 }
 

--- a/backend/src/inputs/user/SignupInput.ts
+++ b/backend/src/inputs/user/SignupInput.ts
@@ -1,21 +1,25 @@
 import { Field, InputType } from "type-graphql";
-import { IsEmail, Length, MaxLength } from "class-validator";
+import { IsEmail, IsNotEmpty, Length, MaxLength } from "class-validator";
 
 @InputType()
 export class SignupInput {
   @Field()
   @MaxLength(100)
+  @IsNotEmpty()
   firstName: string;
 
   @Field()
   @MaxLength(100)
+  @IsNotEmpty()
   lastName: string;
 
   @Field()
   @IsEmail({}, { message: "L'email fourni est invalide" })
+  @IsNotEmpty()
   email: string;
 
   @Field()
-  @Length(6, 255)
+  @Length(6, 255, { message: "Le mot de passe doit contenir au moins 6 caractères." })
+  @IsNotEmpty()
   password: string;
 }

--- a/backend/src/resolvers/BlogResolver.ts
+++ b/backend/src/resolvers/BlogResolver.ts
@@ -1,0 +1,46 @@
+import { Resolver, Mutation, Arg, Query } from 'type-graphql';
+import { Blog } from '../entities/Blog';
+import { BlogInput } from '../inputs/blog/BlogInput';
+import { User } from '../entities/User';
+
+
+@Resolver(Blog)
+export class BlogResolver {
+
+    @Mutation(() => Blog)
+    async createBlog(@Arg("data") data: BlogInput): Promise<Blog> {
+        try {
+            const existing = await Blog.findOneBy({ name: data.name });
+            if (existing) {
+              throw new Error("Un blog existe déjà avec ce nom.");
+            }
+        
+            // FIXME: Remplacer ce fakeAuthor par l'utilisateur connecté quand on aura le contexte
+            const fakeAuthor = await User.findOneBy({ id: 1 });
+            if (!fakeAuthor) {
+              throw new Error("Auteur introuvable.");
+            }
+        
+            const blog = Blog.create({
+              ...data,
+              author: fakeAuthor,
+            });
+        
+            await blog.save();
+            return blog;
+        
+          } catch (error) {
+            throw new Error( "Erreur lors de la création du blog : " + error.message);
+          }
+    }
+
+    @Query(()=> [Blog])
+    async getBlogs() {
+        const blogs = await Blog.find({
+            relations: ["author"]
+        });
+        return blogs;
+    }
+
+
+}

--- a/backend/src/resolvers/UserResolver.ts
+++ b/backend/src/resolvers/UserResolver.ts
@@ -10,23 +10,28 @@ export class UserResolver {
     
     @Mutation(() => User)
     async signUp(@Arg("data") data: SignupInput): Promise<User> {
-
+        
         const existing = await User.findOneBy({ email: data.email } );
         if (existing) {
-            throw new Error("Email already in use");
+            throw new Error("Cette adresse email est déjà utilisée.");
         }
 
         const hashedPassword = await argon2.hash(data.password);
+        
+        try {
+            const user = User.create({
+                firstName: data.firstName,
+                lastName: data.lastName,
+                email: data.email,
+                password: hashedPassword,
+                isActive: true
+            });
+            await user.save();
+            return user;
 
-        const user = User.create({
-            firstName: data.firstName,
-            lastName: data.lastName,
-            email: data.email,
-            password: hashedPassword,
-            isActive: true
-        });
-        await user.save();
-        return user;
+        } catch (error) {
+            throw new Error( "Erreur lors de la création de l'utilisateur : " + error.message);
+        } 
     }
 
     @Mutation(() => String)


### PR DESCRIPTION
Création de l'entité Blog avec :
-slug automatique, 
-relation avec User, 
-mutation GraphQL associée: createBlog et getBlogs

J'ai mutualisé les champs que les entités ont en commun (createdAt et updatedAt, id) dans la classe abstraite BaseTimeEntity, à partir de laquelle on pourra extends nos entités.

note pour plus tard : après mise en place du contexte, on récupérera l'utilisateur courant (connecté)en tant qu'auteur, qui sera directement associé à la création du blog.
